### PR TITLE
Migrate from Webix to jQuery DataTables

### DIFF
--- a/explorer-server/code/styles/index.css
+++ b/explorer-server/code/styles/index.css
@@ -7,6 +7,14 @@ h1, h2, h3, h4, h5 {
   padding: 0!important;
 }
 
+.blur {
+  filter:blur(4px);
+  -o-filter:blur(4px);
+  -ms-filter:blur(4px);
+  -moz-filter:blur(4px);
+  -webkit-filter:blur(4px);
+}
+
 .overflow-y-scroll {
   overflow-y: scroll;
 }
@@ -52,6 +60,10 @@ h1, h2, h3, h4, h5 {
 }
 
 .webix_dtable .hash {
+  font-family: 'Ubuntu Mono';
+}
+
+.hash {
   font-family: 'Ubuntu Mono';
 }
 
@@ -380,8 +392,62 @@ table.tx-details-table tr:last-child td {
   text-align: right;
 }
 
-.block-listing__datatable-container {
+.block-listing__datatable {
   margin-top: 10px;
+}
+
+table.dataTable thead th,
+table.dataTable thead td {
+  border-bottom-color: rgb(251, 123, 129)!important;
+  text-align: left!important;
+  font-family: inherit !important;
+  font-weight: 700;
+  padding-bottom: 8px!important;
+}
+
+table.dataTable tbody td {
+  font-weight: 400;
+  border-bottom: 1px solid #edeff0;
+  padding: 7px 5px!important;
+  color: #475466;
+}
+
+table.dataTable > tbody > tr:last-child > td {
+  border-bottom: 0;
+}
+
+table.dataTable tbody tr:hover {
+  background: rgba(251, 123, 129, 0.1);
+}
+
+table.block-listing__datatable.compact.dataTable thead th {
+  text-align: left!important;
+}
+
+table.dataTable.no-footer {
+  border-bottom: 0!important;
+}
+
+#blocks-table_length {
+  margin-bottom: 10px;
+  float: right;
+}
+
+#blocks-table_paginate {
+  display: none;
+}
+
+#blocks-table_info {
+  display: none;
+}
+
+.dtr-control::before {
+  height: 1em!important;
+  width: 1em!important;
+  background-color: #fb7b81!important;
+  border: none!important;
+  box-shadow: 2px 2px 15px 8px #000000;
+    -webkit-box-shadow: 2px 2px 15px 8px #000000;
 }
 
 .datatable__block_listing
@@ -407,6 +473,15 @@ table.tx-details-table tr:last-child td {
 
 .loader__container {
   width: 100%;
+}
+
+.loader__container--fullpage {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 50%;
+  z-index: 9999;
 }
 
 .loader__outer {

--- a/explorer-server/src/server.rs
+++ b/explorer-server/src/server.rs
@@ -65,6 +65,12 @@ impl Server {
             num_txs: u64,
             median_time: i64,
         }
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct BlockJsonResponse {
+            data: Vec<Block>,
+        }
+
         let mut json_blocks = Vec::with_capacity(blocks.len());
         for (block_hash, block) in blocks.into_iter().rev() {
             json_blocks.push(Block {
@@ -79,7 +85,8 @@ impl Server {
             });
         }
 
-        Ok(serde_json::to_string(&json_blocks)?)
+        let json_response = BlockJsonResponse { data: json_blocks };
+        Ok(serde_json::to_string(&json_response)?)
     }
 }
 

--- a/explorer-server/templates/base.html
+++ b/explorer-server/templates/base.html
@@ -18,9 +18,11 @@
 
   <link rel="stylesheet" href="/code/webix/webix.min.css">
   <link rel="stylesheet" href="/code/semantic-ui/semantic.min.css">
-  <link rel="stylesheet" href="/code/styles/index.css">
+  <link rel="stylesheet" href="/code/styles/index.css?hash=80d7734">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/responsive/2.2.9/css/responsive.dataTables.min.css">
 
   <link rel="manifest" href="site.webmanifest">
   <meta name="theme-color" content="#fafafa">
@@ -28,8 +30,10 @@
   <script src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
   <script type="text/javascript" src="/code/semantic-ui/semantic.min.js?v=0"></script>
   <script type="text/javascript" src="/code/webix/webix.min.js?v=8.1.0"></script>
+  <script type="text/javascript" src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
+  <script type="text/javascript" src="https://cdn.datatables.net/responsive/2.2.9/js/dataTables.responsive.min.js"></script>
   <script type="text/javascript" src="/code/moment.min.js?v=0"></script>
-  <script type="text/javascript" src="/code/common.js"></script>
+  <script type="text/javascript" src="/code/common.js?hash=80d7734"></script>
 </head>
 
 <body class="{% block body_classes %}{% endblock %}">

--- a/explorer-server/templates/components/loader_fullpage.html
+++ b/explorer-server/templates/components/loader_fullpage.html
@@ -1,0 +1,7 @@
+{% macro render() %}
+  <div class="loader__container--fullpage">
+    <div class="loader__outer">
+      <div class="loader"></div>
+    </div>
+  </div>
+{% endmacro %}

--- a/explorer-server/templates/pages/address.html
+++ b/explorer-server/templates/pages/address.html
@@ -133,7 +133,7 @@
                   <div id="sats-coins-table"></div>
                 </div>
 
-                <script type="text/javascript" src="/code/coins.js?v=1"></script>
+                <script type="text/javascript" src="/code/coins.js?hash=80d7734"></script>
               </td>
             </tr>
         {% endmatch %}

--- a/explorer-server/templates/pages/block.html
+++ b/explorer-server/templates/pages/block.html
@@ -96,6 +96,6 @@
   </div>
 
   <script type="text/javascript" src="/data/block/{{ block_hash_string }}/dat.js"></script>
-  <script type="text/javascript" src="/code/txs.js"></script>
-  <script type="text/javascript" src="/code/timestamps.js"></script>
+  <script type="text/javascript" src="/code/txs.js?hash=80d7734"></script>
+  <script type="text/javascript" src="/code/timestamps.js?hash=80d7734"></script>
 {% endblock %}

--- a/explorer-server/templates/pages/blocks.html
+++ b/explorer-server/templates/pages/blocks.html
@@ -1,14 +1,41 @@
 {% extends "base.html" %}
 
-{% import "components/loader.html" as loader %}
+{% import "components/loader_fullpage.html" as loader %}
 
 {% block body_classes %}overflow-y-scroll{% endblock %}
 {% block footer_classes %}hidden{% endblock %}
 
 {% block content %}
   <div class="ui container">
-    <div id="blocks-table" class="block-listing__datatable-container"></div>
     {% call loader::render() %}
+    <div class="dataTables_length datatable__length-placeholder" id="blocks-table_length">
+      <label>
+        Show
+        <select name="blocks-table_length" aria-controls="blocks-table" class="">
+          <option value="100">100</option>
+          <option value="250">250</option>
+          <option value="500">500</option>
+          <option value="1000">1,000</option>
+        </select>
+        entries
+      </label>
+    </div>
+    <table id="blocks-table" class="block-listing__datatable dataTable compact responsive nowrap no-footer" style="width: 100%">
+      <thead>
+          <tr>
+              <th>Age</th>
+              <th>Height</th>
+              <th>Txs</th>
+              <th>Block Hash</th>
+              <th>Size</th>
+              <th>Est. Hashrate</th>
+              <th id="date">Date ()</th>
+              <th></th>
+          </tr>
+      </thead>
+      <tbody class="blur">
+      </tbody>
+    </table>
   </div>
 
   <div class="ui container">
@@ -16,5 +43,5 @@
     </div>
   </div>
 
-  <script type="text/javascript" src="/code/blocks.js"></script>
+  <script type="text/javascript" src="/code/blocks.js?hash=80d7734"></script>
 {% endblock %}

--- a/explorer-server/templates/pages/transaction.html
+++ b/explorer-server/templates/pages/transaction.html
@@ -196,5 +196,5 @@
     </div>
   </div>
 
-  <script type="text/javascript" src="/code/timestamps.js"></script>
+  <script type="text/javascript" src="/code/timestamps.js?hash=80d7734"></script>
 {% endblock %}


### PR DESCRIPTION
For performance reasons Webix tables are being replaced with
jQuery DataTables, for now they will both coexist until every table
is migrated.

Major issues with Webix:

 * Overly complex HTML structure which makes styling harder
 * Hover animations are done via javascript which causes lag when the
   row count increases
 * Rendering is overall slow, this gets more noticeable as row counts
   increase