### PR TITLE
Fix address length menu

### DIFF
--- a/explorer-server/code/address.js
+++ b/explorer-server/code/address.js
@@ -173,7 +173,7 @@ const datatable = () => {
 
   $('#address-txs-table').DataTable({
     searching: false,
-    lengthMenu: [50, 100, 250, 500, 1000],
+    lengthMenu: [50, 100, 200],
     pageLength: DEFAULT_ROWS_PER_PAGE,
     language: {
       loadingRecords: '',


### PR DESCRIPTION
Lengths above 200 entries are rejected by Chronik, so we cap them at that in the menu.