### PR TITLE
Fix token amounts in inputs and outputs

### DIFF
--- a/explorer-server/templates/components/input.html
+++ b/explorer-server/templates/components/input.html
@@ -1,4 +1,4 @@
-{% macro render(index, input, tx) %}
+{% macro render(index, input, tx, slp_genesis_info) %}
   {% let is_token = input.slp_token|check_is_token %}
   {% let destination = input.output_script|destination_from_script(is_token) %}
   {% let decoded_input_script = input.input_script|get_script %}
@@ -52,7 +52,7 @@
           {% when Some with (slp_token) %}
             {% match tx.slp_tx_data %}
               {% when Some with (slp_tx_data) %}
-                {% match slp_tx_data.genesis_info %}
+                {% match slp_genesis_info %}
                   {% when Some with (genesis_info) %}
                     {% if slp_token.amount > 0 || slp_token.is_mint_baton %}
                       {% if slp_token.is_mint_baton %}

--- a/explorer-server/templates/components/output.html
+++ b/explorer-server/templates/components/output.html
@@ -1,4 +1,4 @@
-{% macro render(index, output, tx) %}
+{% macro render(index, output, tx, slp_genesis_info) %}
   {% let is_token = output.slp_token|check_is_token %}
   {% let destination = output.output_script|destination_from_script(is_token) %}
   {% let decoded_output_script = output.output_script|get_script %}
@@ -32,7 +32,7 @@
           {% when Some with (slp_token) %}
             {% match tx.slp_tx_data %}
               {% when Some with (slp_tx_data) %}
-                {% match slp_tx_data.genesis_info %}
+                {% match slp_genesis_info %}
                   {% when Some with (genesis_info) %}
                     {% if slp_token.amount > 0 || slp_token.is_mint_baton %}
                       {% if slp_token.is_mint_baton %}

--- a/explorer-server/templates/pages/transaction.html
+++ b/explorer-server/templates/pages/transaction.html
@@ -172,7 +172,7 @@
         <table id="inputs" class="ui very basic table">
           <tbody>
             {% for input in tx.inputs %}
-              {% call input::render(loop.index0, input, tx) %}
+              {% call input::render(loop.index0, input, tx, slp_genesis_info) %}
             {% endfor %}
           </tbody>
         </table>
@@ -190,7 +190,7 @@
         <table id="outputs" class="ui very basic table">
           <tbody>
             {% for output in tx.outputs %}
-              {% call output::render(loop.index0, output, tx) %}
+              {% call output::render(loop.index0, output, tx, slp_genesis_info) %}
             {% endfor %}
           </tbody>
         </table>


### PR DESCRIPTION
Currently, they use the tx's genesis_info, which is only available for GENESIS txs.

This changes it to use the token's genesis_info, which is available for all other SLP tx types.