### PR TITLE
Fix address transaction pagination

### DIFF
--- a/explorer-server/src/server_http.rs
+++ b/explorer-server/src/server_http.rs
@@ -4,7 +4,7 @@ use crate::{
     server_primitives::{JsonBlocksResponse, JsonTxsResponse},
 };
 use axum::{
-    extract::Path,
+    extract::{Path, Query},
     http::StatusCode,
     response::{Html, IntoResponse, Redirect},
     routing::{get_service, MethodRouter},
@@ -91,7 +91,7 @@ pub async fn data_block_txs(
 
 pub async fn data_address_txs(
     Path(hash): Path<String>,
-    Path(query): Path<HashMap<String, String>>,
+    Query(query): Query<HashMap<String, String>>,
     server: Extension<Arc<Server>>,
 ) -> Result<Json<JsonTxsResponse>, ServerError> {
     Ok(Json(


### PR DESCRIPTION
Currently, the address tx pagination is broken, as query params are parsed by the server incorrectly (by using `Path` instead of the correct `Query`).